### PR TITLE
[SW-24541] Use modern syntax to include git tag as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "querystring": "^0.2.0",
     "saml": "^0.14",
     "xml-crypto": "^0.10.1",
-    "xmldom": "auth0/xmldom#v0.1.19-auth0_1",
+    "xmldom": "git+ssh://github.com/auth0/xmldom#v0.1.19-auth0_1",
     "xpath": "0.0.5",
     "xtend": "^1.0.3"
   },


### PR DESCRIPTION
**Summary**
The old style syntax was not being understood by Snyk in the Eiger repo.

**Test Plan**
Used by Eiger tests which should pass